### PR TITLE
[0.4.0] Add ``get()`` method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.7"
+  - "3.6"
+  - "3.7-dev"
 install:
   - pip install tox-travis
   - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,12 @@ Access EXIF metadata tags using Python attribute notation::
     >>> my_image.model
     'iPhone 7'
     >>>
+    >>> # Alternatively, read tags by leveraging the dictionary-style "get()" method.
+    >>> my_image.get("color_space")
+    <ColorSpace.UNCALIBRATED: 65535>
+    >>> my_image.get("nonexistent_tag")
+    None
+    >>>
     >>> # Modify tags with Python "set" notation.
     >>> my_image.model = "Python"
     >>>

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -16,6 +16,7 @@ Image
 
 .. autoclass:: exif.Image
 
+    .. automethod:: exif.Image.get
     .. automethod:: exif.Image.get_file
 
 ************

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,11 +20,11 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = u'exif'
-copyright = u'2018, Tyler N. Thieding'
+copyright = u'2019, Tyler N. Thieding'
 author = u'Tyler N. Thieding'
 
 # The short X.Y version
-version = u'0.3.1'
+version = u'0.4.0'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,16 @@
 Release Notes
 #############
 
+******************************************
+[0.4.0] Add ``get()`` method. (2019-03-16)
+******************************************
+
+Previously, this package did not offer a mechanism to return a default value when attempting to access a missing tag,
+causing users to rely heavily on try-except statements. Now, the ``Image`` class offers a ``get()`` method. This method
+accepts a ``default=None`` keyword argument specifying the return value if the target attribute does not exist.
+
+See https://github.com/TNThieding/exif/issues/7 for more information.
+
 ***********************************************
 [0.3.1] Fix little endian support. (2018-02-10)
 ***********************************************

--- a/exif/_image.py
+++ b/exif/_image.py
@@ -51,7 +51,7 @@ class Image(object):
         self._parse_segments(img_hex)
 
     def __dir__(self):
-        return ['get_file', '_segments'] + self._segments['APP1'].get_tag_list()
+        return ['get', 'get_file', '_segments'] + self._segments['APP1'].get_tag_list()
 
     def __getattr__(self, item):
         return getattr(self._segments['APP1'], item)
@@ -71,6 +71,25 @@ class Image(object):
             super(Image, self).__setattr__(key, value)
         else:
             setattr(self._segments['APP1'], key, value)
+
+    def get(self, attribute, default=None):
+        """Return the value of the specified attribute.
+
+        If the attribute is not available or set, return the value specified by the ``default``
+        keyword argument.
+
+        :param str attribute: image attribute name
+        :param default: return value if attribute does not exist
+        :returns: tag value if present, ``default`` otherwise
+        :rtype: corresponding Python type
+
+        """
+        try:
+            retval = self.__getattr__(attribute)
+        except AttributeError:
+            retval = default
+
+        return retval
 
     def get_file(self):
         """Generate equivalent binary file contents.

--- a/exif/tests/test_dunder_dir.py
+++ b/exif/tests/test_dunder_dir.py
@@ -24,7 +24,7 @@ class TestGetFile(unittest.TestCase):
             'components_configuration', 'compression', 'datetime', 'datetime_digitized',
             'datetime_original', 'exif_version', 'exposure_bias_value', 'exposure_mode',
             'exposure_program', 'exposure_time', 'f_number', 'flash', 'flashpix_version',
-            'focal_length', 'focal_length_in_35mm_film', 'get_file', 'gps_altitude',
+            'focal_length', 'focal_length_in_35mm_film', 'get', 'get_file', 'gps_altitude',
             'gps_altitude_ref', 'gps_datestamp', 'gps_dest_bearing', 'gps_dest_bearing_ref',
             'gps_horizontal_positioning_error', 'gps_img_direction', 'gps_img_direction_ref',
             'gps_latitude', 'gps_latitude_ref', 'gps_longitude', 'gps_longitude_ref', 'gps_speed',
@@ -43,8 +43,8 @@ class TestGetFile(unittest.TestCase):
             image = Image(image_file)
         dunder_dir_text = '\n'.join(textwrap.wrap(repr(sorted(dir(image))), 90))
         self.assertEqual(dunder_dir_text, Baseline("""
-            ['_exif_ifd_pointer', '_segments', 'color_space', 'compression', 'datetime', 'get_file',
-            'jpeg_interchange_format', 'jpeg_interchange_format_length', 'orientation',
+            ['_exif_ifd_pointer', '_segments', 'color_space', 'compression', 'datetime', 'get',
+            'get_file', 'jpeg_interchange_format', 'jpeg_interchange_format_length', 'orientation',
             'pixel_x_dimension', 'pixel_y_dimension', 'resolution_unit', 'software', 'x_resolution',
             'y_resolution']
             """))

--- a/exif/tests/test_read_exif.py
+++ b/exif/tests/test_read_exif.py
@@ -20,6 +20,12 @@ class TestReadExif(unittest.TestCase):
         with open(grand_canyon, 'rb') as image_file:
             self.image = Image(image_file)
 
+    def test_get_method(self):
+        """Test behavior when accessing tags using the ``get()`` method."""
+        assert not self.image.get('fake_attribute')  # assert returns None
+        assert self.image.get('light_source', default=-1) == -1  # light_source tag not in image
+        assert self.image.get('make') == Baseline("""Apple""")
+
     def test_handle_bad_attribute(self):
         """Verify that accessing a nonexistent attribute raises an AttributeError."""
         with self.assertRaisesRegexp(AttributeError, "unknown image attribute fake_attribute"):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     include_package_data=True,
 
     name='exif',
-    version='0.3.1',
+    version='0.4.0',
     author='Tyler N. Thieding',
     author_email='python@thieding.com',
     maintainer='Tyler N. Thieding',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py37
 
 [testenv]
 deps = -rrequirements-test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37
+envlist = py27, py36, py37
 
 [testenv]
 deps = -rrequirements-test.txt


### PR DESCRIPTION
Previously, this package did not offer a mechanism to return a default value when attempting to access a missing tag, causing users to rely heavily on try-except statements. Now, the ``Image`` class offers a ``get()`` method. This method accepts a ``default=None`` keyword argument specifying the return value if the target attribute does not exist.

See https://github.com/TNThieding/exif/issues/7 for more information.