### PR TITLE
[0.5.0] Add index/item access support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ jobs:
       env: TOXENV=py27
     - python: "3.6"
       env: TOXENV=py36
-    - python: "3.7"
-      env: TOXENV=py37
 install:
   - pip install tox-travis
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 sudo: false
 language: python
-python:
-  - "2.7"
-  - "3.6"
-  - "3.7-dev"
+stages:
+  - prechecks
+jobs:
+  include:
+    - stage: prechecks
+      python: "3.6"
+      env: TOXENV=pylint
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
 install:
   - pip install tox-travis
   - pip install coveralls
-script: tox
+script: tox -e $TOXENV
 after_success:
   coveralls

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Tyler N. Thieding
+Copyright 2019 Tyler N. Thieding
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/README.rst
+++ b/README.rst
@@ -52,18 +52,24 @@ Access EXIF metadata tags using Python attribute notation::
     >>> my_image.model
     'iPhone 7'
     >>>
-    >>> # Alternatively, read tags by leveraging the dictionary-style "get()" method.
-    >>> my_image.get("color_space")
-    <ColorSpace.UNCALIBRATED: 65535>
-    >>> my_image.get("nonexistent_tag")
-    None
-    >>>
     >>> # Modify tags with Python "set" notation.
     >>> my_image.model = "Python"
     >>>
     >>> # Delete tags with Python "del" notation.
     >>> del my_image.gps_latitude
     >>> del my_image.gps_longitude
+
+Alternatively, leverage the dictionary-style ``get`` method to gracefully handle cases where
+attributes do not exist::
+
+    >>> my_image.get("color_space")
+    <ColorSpace.UNCALIBRATED: 65535>
+    >>> my_image.get("nonexistent_tag")
+    None
+
+Tags are also accessible using index notation::
+
+    >>> # TODO
 
 Write the image with modified EXIF metadata to an image file using ``open`` in binary
 write mode::

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ dependencies. For example, batch process image metadata using a Python script.
 Quick Start
 ***********
 
-Open an image with EXIF metadata using the Python ``open`` built-in function. Ensure the
+Open an image with EXIF metadata using the Python ``open()`` built-in function. Ensure the
 binary mode flag is set. Pass this image file object into the ``exif.Image`` class::
 
     >>> from exif import Image
@@ -53,27 +53,18 @@ Access EXIF metadata tags using Python attribute notation::
     'iPhone 7'
     >>>
     >>> # Modify tags with Python "set" notation.
-    >>> my_image.model = "Python"
+    >>> my_image.make = "Python"
     >>>
     >>> # Delete tags with Python "del" notation.
     >>> del my_image.gps_latitude
     >>> del my_image.gps_longitude
 
-Alternatively, leverage the dictionary-style ``get`` method to gracefully handle cases where
-attributes do not exist::
-
-    >>> my_image.get("color_space")
-    <ColorSpace.UNCALIBRATED: 65535>
-    >>> my_image.get("nonexistent_tag")
-    None
-
-Tags are also accessible using index notation::
-
-    >>> # TODO
-
-Write the image with modified EXIF metadata to an image file using ``open`` in binary
+Write the image with modified EXIF metadata to an image file using ``open()`` in binary
 write mode::
 
     >>> with open('modified_image.jpg', 'wb') as new_image_file:
     ...     new_image_file.write(my_image.get_file())
     ...
+
+Refer to the usage page for information and examples of alternative ways to access EXIF tags (e.g.
+with index/item syntax or with methods).

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -16,8 +16,10 @@ Image
 
 .. autoclass:: exif.Image
 
+    .. automethod:: exif.Image.delete
     .. automethod:: exif.Image.get
     .. automethod:: exif.Image.get_file
+    .. automethod:: exif.Image.set
 
 ************
 Enumerations

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = u'2019, Tyler N. Thieding'
 author = u'Tyler N. Thieding'
 
 # The short X.Y version
-version = u'0.4.0'
+version = u'0.5.0'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,16 @@
 Release Notes
 #############
 
+***************************************************
+[0.5.0] Add index/item access support. (2019-04-13)
+***************************************************
+
+Support indexed get, set, and delete access of EXIF tags. Also, offer ``set()`` and ``delete()`` methods.
+
+This release includes the following under-the-hood changes:
+
+- Add minimum Pylint score check to tox configuration.
+
 ******************************************
 [0.4.0] Add ``get()`` method. (2019-03-16)
 ******************************************

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,9 @@ Support indexed get, set, and delete access of EXIF tags. Also, offer ``set()`` 
 This release includes the following under-the-hood changes:
 
 - Add minimum Pylint score check to tox configuration.
+- Update usage page to describe workflow and different access paradigms.
+
+See https://github.com/TNThieding/exif/issues/13 for more information.
 
 ******************************************
 [0.4.0] Add ``get()`` method. (2019-03-16)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,8 +2,109 @@
 Usage
 #####
 
+.. contents::
+  :local:
+
 .. warning::
     Back up your photos before using this tool! You are responsible for any unexpected data loss
     that may occur through improper use of this package.
 
-**Under construction! Coming soon!**
+****************
+Opening an Image
+****************
+
+Open an image with EXIF metadata using the Python ``open()`` built-in function. Ensure the
+binary mode flag (i.e. ``'rb'``) is set. Pass this image file object into the ``exif.Image`` class::
+
+    >>> from exif import Image
+    >>> with open('grand_canyon.jpg', 'rb') as image_file:
+    ...     my_image = Image(image_file)
+    ...
+
+**************
+Accessing Tags
+**************
+
+List all tags present in an image with ``dir()``::
+
+    >>> dir(my_image)
+    ['<unknown EXIF tag 59932>', '<unknown EXIF tag 59933>', '_exif_ifd_pointer', '_gps_ifd_pointer', '_segments', 'aperture
+    _value', 'brightness_value', 'color_space', 'components_configuration', 'compression', 'datetime', 'datetime_digitized',
+     'datetime_original', 'exif_version', 'exposure_bias_value', 'exposure_mode', 'exposure_program', 'exposure_time', 'f_nu
+    mber', 'flash', 'flashpix_version', 'focal_length', 'focal_length_in_35mm_film', 'get_file', 'gps_altitude', 'gps_altitu
+    de_ref', 'gps_datestamp', 'gps_dest_bearing', 'gps_dest_bearing_ref', 'gps_horizontal_positioning_error', 'gps_img_direc
+    tion', 'gps_img_direction_ref', 'gps_latitude', 'gps_latitude_ref', 'gps_longitude', 'gps_longitude_ref', 'gps_speed', '
+    gps_speed_ref', 'gps_timestamp', 'jpeg_interchange_format', 'jpeg_interchange_format_length', 'lens_make', 'lens_model',
+     'lens_specification', 'make', 'maker_note', 'metering_mode', 'model', 'orientation', 'photographic_sensitivity', 'pixel
+    _x_dimension', 'pixel_y_dimension', 'resolution_unit', 'scene_capture_type', 'scene_type', 'sensing_method', 'shutter_sp
+    eed_value', 'software', 'subject_area', 'subsec_time_digitized', 'subsec_time_original', 'white_balance', 'x_resolution',
+    'y_and_c_positioning', 'y_resolution']
+
+The ``Image`` class facilitates three different tag access paradigms. Leverage attribute syntax for
+an intuitive object-oriented feel. Alternatively, leverage indexed/item syntax of additional methods
+for more control.
+
+Attribute Syntax
+++++++++++++++++
+
+Access EXIF tag values as attributes of the ``Image`` instance::
+
+    >>> my_image.gps_latitude
+    (36.0, 3.0, 11.08)
+    >>> my_image.gps_longitude
+    (112.0, 5.0, 4.18)
+    >>> my_image.make
+    'Apple'
+    >>> my_image.model
+    'iPhone 7'
+
+Change the EXIF tag value by modifying the attribute value::
+
+    >>> my_image.make = "Python"
+
+Use ``del`` notation to remove EXIF tags from the image::
+
+    >>> del my_image.gps_latitude
+    >>> del my_image.gps_longitude
+
+Indexed/Item Syntax
++++++++++++++++++++
+
+Alternatively, use indexed/item syntax to read, modify, and remove attribute tags::
+
+    >>> my_image["orientation"]
+    1
+    >>> my_image["software"] = "Python Script"
+    >>> del my_image["maker_note"]
+
+
+Methods
++++++++
+
+Leverage the dictionary-style ``get()`` method to gracefully handle cases where attributes do not
+exist::
+
+    >>> my_image.get("color_space")
+    <ColorSpace.UNCALIBRATED: 65535>
+    >>> my_image.get("nonexistent_tag")
+    None
+
+Call ``set()`` with a tag name and value to modify it::
+
+    >>> self.image.set("model", "EXIF Package")
+
+Call ``delete()`` with a tag name to remove it from the image::
+
+    >>> self.image.delete("datetime_original")
+
+
+************************
+Writing/Saving the Image
+************************
+
+Write the image with modified EXIF metadata to an image file using ``open()`` in binary
+write (i.e. ``'wb'``) mode::
+
+    >>> with open('modified_image.jpg', 'wb') as new_image_file:
+    ...     new_image_file.write(my_image.get_file())
+    ...

--- a/exif/_image.py
+++ b/exif/_image.py
@@ -56,14 +56,6 @@ class Image(object):
     def __getattr__(self, item):
         return getattr(self._segments['APP1'], item)
 
-    def __delattr__(self, item):
-        try:
-            ATTRIBUTE_ID_MAP[item]
-        except KeyError:
-            super(Image, self).__delattr__(item)
-        else:
-            delattr(self._segments['APP1'], item)
-
     def __setattr__(self, key, value):
         try:
             ATTRIBUTE_ID_MAP[key]
@@ -72,13 +64,38 @@ class Image(object):
         else:
             setattr(self._segments['APP1'], key, value)
 
+    def __delattr__(self, item):
+        try:
+            ATTRIBUTE_ID_MAP[item]
+        except KeyError:
+            super(Image, self).__delattr__(item)
+        else:
+            delattr(self._segments['APP1'], item)
+
+    def __getitem__(self, item):
+        return self.__getattr__(item)
+
+    def __setitem__(self, key, value):
+        self.__setattr__(key, value)
+
+    def __delitem__(self, key):
+        self.__delattr__(key)
+
+    def delete(self, attribute):
+        """Remove the specified attribute from the image.
+
+        :param str attribute: image EXIF attribute name
+
+        """
+        self.__delattr__(attribute)
+
     def get(self, attribute, default=None):
         """Return the value of the specified attribute.
 
         If the attribute is not available or set, return the value specified by the ``default``
         keyword argument.
 
-        :param str attribute: image attribute name
+        :param str attribute: image EXIF attribute name
         :param default: return value if attribute does not exist
         :returns: tag value if present, ``default`` otherwise
         :rtype: corresponding Python type
@@ -101,3 +118,13 @@ class Image(object):
         img_hex = (self._segments['preceding'] + self._segments['APP1'].get_segment_hex() +
                    self._segments['succeeding'])
         return binascii.unhexlify(img_hex)
+
+    def set(self, attribute, value):
+        """Set the value of the specified attribute.
+
+        :param str attribute: image EXIF attribute name
+        :param value: tag value
+        :type value: corresponding Python type
+
+        """
+        self.__setattr__(attribute, value)

--- a/exif/tests/test_delete_exif.py
+++ b/exif/tests/test_delete_exif.py
@@ -50,10 +50,24 @@ class TestModifyExif(unittest.TestCase):
         segment_hex = self.image._segments['APP1'].get_segment_hex()
         self.assertEqual('\n'.join(textwrap.wrap(segment_hex, 90)), DELETE_GEOTAG_HEX_BASELINE)
 
+    def test_delete_method(self):
+        """Test behavior when setting tags using the ``delete()`` method."""
+        self.image.delete("model")
+
+        with self.assertRaisesRegexp(AttributeError, "image does not have attribute model"):
+            self.image.model
+
     def test_handle_unset_attribute(self):
         """Verify that accessing an attribute not present in an image raises an AttributeError."""
         with self.assertRaisesRegexp(AttributeError, "image does not have attribute light_source"):
             del self.image.light_source
+
+    def test_index_deleter(self):
+        """Test deleting attributes using index syntax."""
+        del self.image["model"]
+
+        with self.assertRaisesRegexp(AttributeError, "image does not have attribute model"):
+            self.image.model
 
     def test_standard_delete(self):
         """Verify that writing and deleting non-EXIF attributes behave normally."""

--- a/exif/tests/test_modify_exif.py
+++ b/exif/tests/test_modify_exif.py
@@ -34,6 +34,11 @@ class TestModifyExif(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "string must be no longer than original"):
             self.image.model = "MyArtificiallySetCameraAttribute"
 
+    def test_index_modifier(self):
+        """Test modifying attributes using index syntax."""
+        self.image["model"] = "MyCamera"
+        self.assertEqual(self.image.model, Baseline("""MyCamera"""))
+
     def test_modify_ascii_same_len(self):
         """Verify that writing a same length string to an ASCII tag updates the tag."""
         self.image.model = "MyCamera"
@@ -71,3 +76,8 @@ class TestModifyExif(unittest.TestCase):
         segment_hex = self.image._segments['APP1'].get_segment_hex()
         self.assertEqual('\n'.join(textwrap.wrap(segment_hex, 90)),
                          MODIFY_SRATIONAL_HEX_BASELINE)
+
+    def test_set_method(self):
+        """Test behavior when setting tags using the ``set()`` method."""
+        self.image.set("model", "MyCamera")
+        self.assertEqual(self.image.model, Baseline("""MyCamera"""))

--- a/exif/tests/test_read_exif.py
+++ b/exif/tests/test_read_exif.py
@@ -22,9 +22,9 @@ class TestReadExif(unittest.TestCase):
 
     def test_get_method(self):
         """Test behavior when accessing tags using the ``get()`` method."""
-        assert not self.image.get('fake_attribute')  # assert returns None
-        assert self.image.get('light_source', default=-1) == -1  # light_source tag not in image
-        assert self.image.get('make') == Baseline("""Apple""")
+        self.assertIsNone(self.image.get('fake_attribute'))
+        self.assertEqual(self.image.get('light_source', default=-1), -1)  # tag not in image
+        self.assertEqual(self.image.get('make'), Baseline("""Apple"""))
 
     def test_handle_bad_attribute(self):
         """Verify that accessing a nonexistent attribute raises an AttributeError."""
@@ -35,6 +35,10 @@ class TestReadExif(unittest.TestCase):
         """Verify that accessing an attribute not present in an image raises an AttributeError."""
         with self.assertRaisesRegexp(AttributeError, "image does not have attribute light_source"):
             self.image.light_source
+
+    def test_index_accessor(self):
+        """Test accessing attributes using index syntax."""
+        self.assertEqual(self.image["datetime"], Baseline("""2018:03:12 10:12:07"""))
 
     def test_read_ascii(self):
         """Test reading ASCII tags and compare to known baseline values."""

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     include_package_data=True,
 
     name='exif',
-    version='0.4.0',
+    version='0.5.0',
     author='Tyler N. Thieding',
     author_email='python@thieding.com',
     maintainer='Tyler N. Thieding',

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,10 @@ commands =
     coverage run --source exif -m unittest discover
     coverage report --omit="*/test*"
     coverage html --omit="*/test*"
+
+[testenv:pylint]
+deps =
+    -rrequirements-test.txt
+    pylint-fail-under
+commands =
+    pylint-fail-under --fail_under 9.0 exif


### PR DESCRIPTION
Support indexed get, set, and delete access of EXIF tags. Also, offer ``set()`` and ``delete()`` methods.

This release includes the following under-the-hood changes:

- Add minimum Pylint score check to tox configuration.
- Update usage page to describe workflow and different access paradigms.

See https://github.com/TNThieding/exif/issues/13 for more information.