### PR TITLE
(feat) Image constructor also takes a file that was already been read

### DIFF
--- a/exif/_image.py
+++ b/exif/_image.py
@@ -61,7 +61,12 @@ class Image:
         self.has_exif = True
         self._segments = {}
 
-        img_hex = binascii.hexlify(img_file.read()).upper()
+        try:
+            data = img_file.read()
+        except AttributeError:
+            data = img_file
+
+        img_hex = binascii.hexlify(data).upper()
         if sys.version_info[0] == 3:  # pragma: no cover
             img_hex = img_hex.decode("utf8")
 


### PR DESCRIPTION
This allows exif to work in an async context (at least for reading files).

In an async world, I would like to be able to do something like:

```
async def _get_timestamp_from_exif(self, attr: Enum) -> datetime:
    async with aiofiles.open(self._target, mode='rb') as f:
        img = Image(await f.read())

        if not img.has_exif:
            return
```